### PR TITLE
MAINT: rm _tuple_sorter

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,16 +106,6 @@ fn directed_hausdorff_core(
     (cmax.sqrt(), i_ret, j_ret)
 }
 
-fn _tuple_sorter() {
-    // this function should accept a data structure
-    // that contains the (cmax, i, j) tuples from parallel
-    // threads and returns the true directed hausdorff
-    // tuple, which would be the one with largest cmax
-    // so, some kind of sorting work
-    // NOTE: have not decided how the tuples will
-    // be stored as a group just yet
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
* remove the `_tuple_sorter()` stub function, since it turns
out the reverse sorting of these data structures is just a
1-liner that is now passing tests for parallel workflows

Fixes #3