### PR TITLE
DOC: remove shuffle TODO

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,9 +10,6 @@ pub fn directed_hausdorff(
     ar2: Arc<Array2<f64>>,
     workers: usize,
 ) -> (f64, usize, usize) {
-    // TODO: decide if we're going to use random
-    // shuffling in the Rust version to match
-    // the SciPy implementation?
     let chunk_size;
     let mut start;
     let mut stop;


### PR DESCRIPTION
* shuffling has been added for both arrays in
the calculation, so remove the `TODO` related
to addition of shuffling