### PR TITLE
DOC, MAINT: add repo to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
 name = "rusty_hausdorff"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Tyler Reddy <tyler.je.reddy@gmail.com>"]
 edition = "2018"
 description = "A parallel implementation of the directed Hausdorff distance."
 license = "MIT OR Apache-2.0"
+repository = "https://github.com/tylerjereddy/rusty_hausdorff"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
* add `repository` metadata to `Cargo.toml` so that
it can show up at i.e., `crates.io` page for the
project