### PR TITLE
DOC, BENCH: link to perf comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,7 @@ This is a Rust implementation of the directed [Hausdorff distance](https://en.wi
 It is currently intended as an experiment to see if it can be
 built to outperform the SciPy implementation of [`directed_hausdorff()`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.spatial.distance.directed_hausdorff.html)
 by leveraging i.e., safe concurrency in Rust.
+
+Initial performance comparison with the serial SciPy
+implementation [shows substantial performance improvements](https://github.com/scipy/scipy/issues/14719)
+with the parallel Rust code in this project.


### PR DESCRIPTION
Fixes #16

* update README with a link to the SciPy issue
where I compare performance with the Rust
implementation