### PR TITLE
DOC: add categories

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 description = "A parallel implementation of the directed Hausdorff distance."
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/tylerjereddy/rusty_hausdorff"
+categories = ["science", "mathematics", "algorithms"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
* add categories to the cargo/crate metadata to
improve discoverability

Choices are limited to one of the slugs here: https://crates.io/category_slugs