### PR TITLE
DOC: add GA status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+![test status](https://github.com/tylerjereddy/rusty_hausdorff/actions/workflows/linux.yml/badge.svg)
+
 This is a Rust implementation of the directed [Hausdorff distance](https://en.wikipedia.org/wiki/Hausdorff_distance).
 It is currently intended as an experiment to see if it can be
 built to outperform the SciPy implementation of [`directed_hausdorff()`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.spatial.distance.directed_hausdorff.html)


### PR DESCRIPTION
* it should show up on `crates.io` the next time
I publish a release as well